### PR TITLE
block_children fetch data recursively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,4 @@
   * Bump requests to 2.33.0 for security updates [#14](https://github.com/singer-io/tap-notion/pull/14)
 
 ## 0.0.1
- * Initial Release
+  * Initial Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,5 @@
- * Initial Commit
+## 0.0.2
+  * Recursively requests `block_children` data when `has_children` is true [#13](https://github.com/singer-io/tap-notion/pull/13)
+
+## 0.0.1
+ * Initial Release

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="tap-notion",
-      version="0.0.1",
+      version="0.0.2",
       description="Singer.io tap for extracting data from Notion API",
       author="Stitch",
       url="http://singer.io",

--- a/tap_notion/streams/block_children.py
+++ b/tap_notion/streams/block_children.py
@@ -38,8 +38,10 @@ class BlockChildren(FullTableStream):
 
     def sync(self, state: Dict, transformer: Transformer, parent_obj: Dict = None) -> int:
         """
-        Sync block children recursively. For any child block with has_children=True,
-        fetch and emit its children as well, continuing until the full hierarchy is covered.
+        Sync block children. Recursively fetches children for any nested block
+        (parent.type == "block_id"). Blocks whose parent is a page (parent.type == "page_id")
+        are top-level blocks already covered by the Blocks stream and are not recursed into,
+        which prevents duplicate records.
         """
         self.url_endpoint = self.get_url_endpoint(parent_obj)
         with metrics.record_counter(self.tap_stream_id) as counter:
@@ -50,11 +52,8 @@ class BlockChildren(FullTableStream):
                     write_record(self.tap_stream_id, transformed_record)
                     counter.increment()
 
-                for child in self.child_to_sync:
-                    child.sync(state=state, transformer=transformer, parent_obj=record)
-
-                if record.get("has_children"):
-                    block = BlockChildren(self.client, self.catalog)
-                    block.sync(state=state, transformer=transformer, parent_obj=record)
+                is_nested = record.get("parent", {}).get("type") == "block_id"
+                if record.get("has_children") and is_nested:
+                    self.sync(state=state, transformer=transformer, parent_obj=record)
 
             return counter.value

--- a/tap_notion/streams/block_children.py
+++ b/tap_notion/streams/block_children.py
@@ -54,6 +54,7 @@ class BlockChildren(FullTableStream):
 
                 is_nested = record.get("parent", {}).get("type") == "block_id"
                 if record.get("has_children") and is_nested:
-                    self.sync(state=state, transformer=transformer, parent_obj=record)
+                    child = BlockChildren(self.client, self.catalog)
+                    child.sync(state=state, transformer=transformer, parent_obj=record)
 
             return counter.value

--- a/tap_notion/streams/block_children.py
+++ b/tap_notion/streams/block_children.py
@@ -32,6 +32,8 @@ class BlockChildren(FullTableStream):
         """
         if parent_record:
             record["block_id"] = parent_record.get("id")
+        else:
+            record.pop("block_id", None)
         return record
 
     def sync(self, state: Dict, transformer: Transformer, parent_obj: Dict = None) -> int:
@@ -48,7 +50,11 @@ class BlockChildren(FullTableStream):
                     write_record(self.tap_stream_id, transformed_record)
                     counter.increment()
 
+                for child in self.child_to_sync:
+                    child.sync(state=state, transformer=transformer, parent_obj=record)
+
                 if record.get("has_children"):
-                    self.sync(state=state, transformer=transformer, parent_obj=record)
+                    block = BlockChildren(self.client, self.catalog)
+                    block.sync(state=state, transformer=transformer, parent_obj=record)
 
             return counter.value

--- a/tap_notion/streams/block_children.py
+++ b/tap_notion/streams/block_children.py
@@ -32,16 +32,12 @@ class BlockChildren(FullTableStream):
         """
         if parent_record:
             record["block_id"] = parent_record.get("id")
-        else:
-            record.pop("block_id", None)
         return record
 
     def sync(self, state: Dict, transformer: Transformer, parent_obj: Dict = None) -> int:
         """
         Sync block children. Recursively fetches children for any nested block
-        (parent.type == "block_id"). Blocks whose parent is a page (parent.type == "page_id")
-        are top-level blocks already covered by the Blocks stream and are not recursed into,
-        which prevents duplicate records.
+        (parent.type == "block_id").
         """
         self.url_endpoint = self.get_url_endpoint(parent_obj)
         with metrics.record_counter(self.tap_stream_id) as counter:
@@ -55,6 +51,7 @@ class BlockChildren(FullTableStream):
                 is_nested = record.get("parent", {}).get("type") == "block_id"
                 if record.get("has_children") and is_nested:
                     child = BlockChildren(self.client, self.catalog)
+                    child.is_selected = self.is_selected
                     child.sync(state=state, transformer=transformer, parent_obj=record)
 
             return counter.value

--- a/tap_notion/streams/block_children.py
+++ b/tap_notion/streams/block_children.py
@@ -1,5 +1,5 @@
 from typing import Dict
-from singer import get_logger
+from singer import Transformer, get_logger, metrics, write_record
 from tap_notion.streams.abstracts import FullTableStream
 
 LOGGER = get_logger()
@@ -25,7 +25,7 @@ class BlockChildren(FullTableStream):
             raise ValueError("Missing 'id' in parent object for BlockChildren.")
 
         return f"{self.client.base_url}/{self.path.format(block_id=block_id)}"
-    
+
     def modify_object(self, record: Dict, parent_record: Dict = None) -> Dict:
         """
         Modify the record before writing to the stream
@@ -33,3 +33,22 @@ class BlockChildren(FullTableStream):
         if parent_record:
             record["block_id"] = parent_record.get("id")
         return record
+
+    def sync(self, state: Dict, transformer: Transformer, parent_obj: Dict = None) -> int:
+        """
+        Sync block children recursively. For any child block with has_children=True,
+        fetch and emit its children as well, continuing until the full hierarchy is covered.
+        """
+        self.url_endpoint = self.get_url_endpoint(parent_obj)
+        with metrics.record_counter(self.tap_stream_id) as counter:
+            for record in self.get_records(parent_obj=parent_obj):
+                record = self.modify_object(record, parent_obj)
+                transformed_record = transformer.transform(record, self.schema, self.metadata)
+                if self.is_selected():
+                    write_record(self.tap_stream_id, transformed_record)
+                    counter.increment()
+
+                if record.get("has_children"):
+                    self.sync(state=state, transformer=transformer, parent_obj=record)
+
+            return counter.value

--- a/tests/unittests/test_block_children.py
+++ b/tests/unittests/test_block_children.py
@@ -63,7 +63,7 @@ def test_sync_recurses_into_nested_children(mock_write_record, mock_counter, moc
     # First call returns a child block that itself has children
     # Second call (recursive) returns a grandchild with no further children
     mock_client.get.side_effect = [
-        {"results": [{"id": "child-1", "has_children": True}], "next_cursor": None},
+        {"results": [{"id": "child-1", "has_children": True, "parent": {"type": "block_id"}}], "next_cursor": None},
         {"results": [{"id": "grandchild-1", "has_children": False}], "next_cursor": None},
     ]
 
@@ -91,7 +91,7 @@ def test_sync_recurses_into_nested_children(mock_write_record, mock_counter, moc
 def test_sync_grandchild_has_correct_block_id(mock_write_record, mock_counter, mock_catalog, mock_client):
     """Each record's block_id should reference its direct parent, not the top-level parent."""
     mock_client.get.side_effect = [
-        {"results": [{"id": "child-1", "has_children": True}], "next_cursor": None},
+        {"results": [{"id": "child-1", "has_children": True, "parent": {"type": "block_id"}}], "next_cursor": None},
         {"results": [{"id": "grandchild-1", "has_children": False}], "next_cursor": None},
     ]
 
@@ -121,7 +121,7 @@ def test_sync_grandchild_has_correct_block_id(mock_write_record, mock_counter, m
 def test_sync_not_selected_skips_write_but_still_recurses(mock_write_record, mock_counter, mock_catalog, mock_client):
     """Even when the stream is not selected, recursion should still occur (matching base class behavior)."""
     mock_client.get.side_effect = [
-        {"results": [{"id": "child-1", "has_children": True}], "next_cursor": None},
+        {"results": [{"id": "child-1", "has_children": True, "parent": {"type": "block_id"}}], "next_cursor": None},
         {"results": [{"id": "grandchild-1", "has_children": False}], "next_cursor": None},
     ]
 

--- a/tests/unittests/test_block_children.py
+++ b/tests/unittests/test_block_children.py
@@ -1,0 +1,142 @@
+"""
+Unit tests for BlockChildren stream recursive sync behavior.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch, call
+from tap_notion.streams.block_children import BlockChildren
+
+
+@pytest.fixture
+def mock_catalog():
+    catalog = MagicMock()
+    catalog.schema.to_dict.return_value = {
+        "type": "object",
+        "properties": {
+            "id": {"type": "string"},
+            "block_id": {"type": "string"},
+            "has_children": {"type": "boolean"},
+        }
+    }
+    catalog.metadata = []
+    return catalog
+
+
+@pytest.fixture
+def mock_client():
+    client = MagicMock()
+    client.base_url = "https://api.notion.com/v1"
+    client.config = {"start_date": "2024-01-01T00:00:00Z"}
+    return client
+
+
+@patch("tap_notion.streams.block_children.metrics.record_counter")
+@patch("tap_notion.streams.block_children.write_record")
+def test_sync_no_children(mock_write_record, mock_counter, mock_catalog, mock_client):
+    """Blocks with has_children=False are emitted but not recursed into."""
+    mock_client.get.return_value = {
+        "results": [{"id": "block-1", "has_children": False}],
+        "next_cursor": None,
+    }
+    counter_inst = MagicMock()
+    counter_inst.__enter__.return_value = counter_inst
+    counter_inst.__exit__.return_value = False
+    counter_inst.value = 1
+    mock_counter.return_value = counter_inst
+
+    stream = BlockChildren(client=mock_client, catalog=mock_catalog)
+    stream.is_selected = MagicMock(return_value=True)
+    transformer = MagicMock()
+    transformer.transform.side_effect = lambda r, s, m: r
+
+    stream.sync(state={}, transformer=transformer, parent_obj={"id": "parent-block"})
+
+    assert mock_write_record.call_count == 1
+    # Only one GET request — no recursion
+    assert mock_client.get.call_count == 1
+
+
+@patch("tap_notion.streams.block_children.metrics.record_counter")
+@patch("tap_notion.streams.block_children.write_record")
+def test_sync_recurses_into_nested_children(mock_write_record, mock_counter, mock_catalog, mock_client):
+    """Blocks with has_children=True trigger a recursive sync call."""
+    # First call returns a child block that itself has children
+    # Second call (recursive) returns a grandchild with no further children
+    mock_client.get.side_effect = [
+        {"results": [{"id": "child-1", "has_children": True}], "next_cursor": None},
+        {"results": [{"id": "grandchild-1", "has_children": False}], "next_cursor": None},
+    ]
+
+    counter_inst = MagicMock()
+    counter_inst.__enter__.return_value = counter_inst
+    counter_inst.__exit__.return_value = False
+    counter_inst.value = 1
+    mock_counter.return_value = counter_inst
+
+    stream = BlockChildren(client=mock_client, catalog=mock_catalog)
+    stream.is_selected = MagicMock(return_value=True)
+    transformer = MagicMock()
+    transformer.transform.side_effect = lambda r, s, m: r
+
+    stream.sync(state={}, transformer=transformer, parent_obj={"id": "parent-block"})
+
+    # Both child and grandchild should be written
+    assert mock_write_record.call_count == 2
+    # Two GET requests: one for the child level, one for the grandchild level
+    assert mock_client.get.call_count == 2
+
+
+@patch("tap_notion.streams.block_children.metrics.record_counter")
+@patch("tap_notion.streams.block_children.write_record")
+def test_sync_grandchild_has_correct_block_id(mock_write_record, mock_counter, mock_catalog, mock_client):
+    """Each record's block_id should reference its direct parent, not the top-level parent."""
+    mock_client.get.side_effect = [
+        {"results": [{"id": "child-1", "has_children": True}], "next_cursor": None},
+        {"results": [{"id": "grandchild-1", "has_children": False}], "next_cursor": None},
+    ]
+
+    counter_inst = MagicMock()
+    counter_inst.__enter__.return_value = counter_inst
+    counter_inst.__exit__.return_value = False
+    counter_inst.value = 1
+    mock_counter.return_value = counter_inst
+
+    stream = BlockChildren(client=mock_client, catalog=mock_catalog)
+    stream.is_selected = MagicMock(return_value=True)
+    transformer = MagicMock()
+    transformer.transform.side_effect = lambda r, s, m: r
+
+    stream.sync(state={}, transformer=transformer, parent_obj={"id": "parent-block"})
+
+    written_records = [c.args[1] for c in mock_write_record.call_args_list]
+    child_record = next(r for r in written_records if r["id"] == "child-1")
+    grandchild_record = next(r for r in written_records if r["id"] == "grandchild-1")
+
+    assert child_record["block_id"] == "parent-block"
+    assert grandchild_record["block_id"] == "child-1"
+
+
+@patch("tap_notion.streams.block_children.metrics.record_counter")
+@patch("tap_notion.streams.block_children.write_record")
+def test_sync_not_selected_skips_write_but_still_recurses(mock_write_record, mock_counter, mock_catalog, mock_client):
+    """Even when the stream is not selected, recursion should still occur (matching base class behavior)."""
+    mock_client.get.side_effect = [
+        {"results": [{"id": "child-1", "has_children": True}], "next_cursor": None},
+        {"results": [{"id": "grandchild-1", "has_children": False}], "next_cursor": None},
+    ]
+
+    counter_inst = MagicMock()
+    counter_inst.__enter__.return_value = counter_inst
+    counter_inst.__exit__.return_value = False
+    counter_inst.value = 0
+    mock_counter.return_value = counter_inst
+
+    stream = BlockChildren(client=mock_client, catalog=mock_catalog)
+    stream.is_selected = MagicMock(return_value=False)
+    transformer = MagicMock()
+    transformer.transform.side_effect = lambda r, s, m: r
+
+    stream.sync(state={}, transformer=transformer, parent_obj={"id": "parent-block"})
+
+    mock_write_record.assert_not_called()
+    assert mock_client.get.call_count == 2

--- a/tests/unittests/test_block_children.py
+++ b/tests/unittests/test_block_children.py
@@ -140,3 +140,38 @@ def test_sync_not_selected_skips_write_but_still_recurses(mock_write_record, moc
 
     mock_write_record.assert_not_called()
     assert mock_client.get.call_count == 2
+
+
+@patch("tap_notion.streams.block_children.metrics.record_counter")
+@patch("tap_notion.streams.block_children.write_record")
+def test_sync_recurses_beyond_depth_2(mock_write_record, mock_counter, mock_catalog, mock_client):
+    """Recursion continues past depth 2 — great-grandchildren are also fetched and written."""
+    mock_client.get.side_effect = [
+        {"results": [{"id": "child-1", "has_children": True, "parent": {"type": "block_id"}}], "next_cursor": None},
+        {"results": [{"id": "grandchild-1", "has_children": True, "parent": {"type": "block_id"}}], "next_cursor": None},
+        {"results": [{"id": "great-grandchild-1", "has_children": False}], "next_cursor": None},
+    ]
+
+    counter_inst = MagicMock()
+    counter_inst.__enter__.return_value = counter_inst
+    counter_inst.__exit__.return_value = False
+    counter_inst.value = 1
+    mock_counter.return_value = counter_inst
+
+    stream = BlockChildren(client=mock_client, catalog=mock_catalog)
+    stream.is_selected = MagicMock(return_value=True)
+    transformer = MagicMock()
+    transformer.transform.side_effect = lambda r, s, m: r
+
+    stream.sync(state={}, transformer=transformer, parent_obj={"id": "parent-block"})
+
+    assert mock_write_record.call_count == 3
+    assert mock_client.get.call_count == 3
+
+    written_records = [c.args[1] for c in mock_write_record.call_args_list]
+    ids = [r["id"] for r in written_records]
+    assert ids == ["child-1", "grandchild-1", "great-grandchild-1"]
+
+    assert written_records[0]["block_id"] == "parent-block"
+    assert written_records[1]["block_id"] == "child-1"
+    assert written_records[2]["block_id"] == "grandchild-1"


### PR DESCRIPTION
# Description of change
https://qlik-dev.atlassian.net/browse/SAC-31184

Recursively pulls all `block_children` elements.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
