### PR TITLE
SAC-31223: Using type webhook for in-memory backend

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -27,7 +27,7 @@ class NotionBaseTest(BaseCase):
     @staticmethod
     def get_type():
         """The name of the tap."""
-        return "platform.notion"
+        return "webhook.notion"
 
     @classmethod
     def expected_metadata(cls):


### PR DESCRIPTION
# Description of change
JIRA: https://qlik-dev.atlassian.net/browse/SAC-31223

**Changes:**
Using type webhook for in-memory backend tests. This tap notion uses in-memory backend for running integration tests
