### PR TITLE
SAC-31379: Replacing logic with dynamic nest data creation

### DIFF
--- a/tests/test_nested_data_hierarchy.py
+++ b/tests/test_nested_data_hierarchy.py
@@ -1,14 +1,35 @@
+import os
+
+import requests
+
 from base import NotionBaseTest
 from tap_tester import connections, runner
+
+NOTION_API_BASE = "https://api.notion.com/v1"
+# Keep this local so the test does not depend on importing tap_notion package.
+NOTION_VERSION = os.getenv("TAP_NOTION_VERSION", "2025-09-03")
 
 
 class NotionNestedHierarchyTest(NotionBaseTest):
     """
-    Validate parent-child-grandchild replication integrity for Notion.
+        Dynamically creates a branched 3-level nested page hierarchy in Notion, runs a
+    sync, validates that all levels are replicated, then archives the test
+    data.
+
+    Hierarchy created:
+                page
+                    └─ text_1
+                             ├─ text_1_child1
+                             └─ text_1_child2
+                                        ├─ text1_child2_grandchild1
+                                        └─ text1_child2_grandchild2
 
     This lives in tap-notion for now because nested grandchild coverage is
-    currently needed only for taps that expose this hierarchy pattern.
+    needed only for taps that expose this hierarchy pattern.
     """
+
+    STREAMS_TO_SYNC = {"pages", "blocks", "block_children"}
+    PARENT_PAGE_ID = "38a0dbd4-4275-80c5-a531-e55f1eaba109"
 
     @staticmethod
     def name():
@@ -16,40 +37,103 @@ class NotionNestedHierarchyTest(NotionBaseTest):
 
     @staticmethod
     def streams_to_selected_fields():
-        # Empty mapping means select all fields for selected streams.
         return {}
 
+    @staticmethod
+    def _normalize_id(value):
+        """Normalize Notion ids so dashed/undashed forms compare equally."""
+        if not value:
+            return ""
+        return str(value).replace("-", "").lower()
+
+    # Notion API helpers (used only for test data management)
+
+    def _notion_headers(self):
+        token = os.getenv("TAP_NOTION_AUTH_TOKEN")
+        return {
+            "Authorization": f"Bearer {token}",
+            "Notion-Version": NOTION_VERSION,
+            "Content-Type": "application/json",
+        }
+
+    def _bulleted_list_item_block(self, text):
+        """Return a minimal bulleted list item block payload."""
+        return {
+            "object": "block",
+            "type": "bulleted_list_item",
+            "bulleted_list_item": {
+                "rich_text": [{"type": "text", "text": {"content": text}}]
+            },
+        }
+
+
+
+    def _append_block(self, parent_block_id, text):
+        """Append one bulleted list item block to parent_block_id and return its id."""
+        resp = requests.patch(
+            f"{NOTION_API_BASE}/blocks/{parent_block_id}/children",
+            headers=self._notion_headers(),
+            json={"children": [self._bulleted_list_item_block(text)]},
+        )
+        resp.raise_for_status()
+        return resp.json()["results"][0]["id"]
+
+    def _archive_block(self, block_id):
+        """Archive (soft-delete) a block and all its nested content."""
+        resp = requests.patch(
+            f"{NOTION_API_BASE}/blocks/{block_id}",
+            headers=self._notion_headers(),
+            json={"archived": True},
+        )
+        resp.raise_for_status()
+
+    # Validating the nested hierarchy replication
     def test_parent_child_grandchild_replication(self):
         """
-        Verify hierarchical replication with this model:
-        pages -> blocks (parents) -> block_children (descendants).
-
-        In this tap, block_children contains child and grandchild-level records.
-
-        Scenario expectation (simple):
-        if some parent blocks have nested descendants, descendant records should
-        be present in target output. If a child has no grandchildren, this test
-        should still pass.
+        1. Dynamically create a 3-level branched Notion hierarchy under a fixed parent page.
+        2. Sync pages / blocks / block_children.
+        3. Assert every level is present in the target output with correct
+           primary keys and parent-child linkage.
+        4. Archive the top-level test block (cleanup runs even on failure).
         """
-        
-        # Checking for relevant streams
+        # --- set up connection first ------------------------------------
+        # Establish connection and bookmark BEFORE creating test data so the
+        # sync captures all newly created records in its window.
         conn_id = connections.ensure_connection(self)
         found_catalogs = self.run_and_verify_check_mode(conn_id)
-        streams_to_sync = {"pages", "blocks", "block_children"}
-        test_catalogs = [catalog for catalog in found_catalogs
-            if catalog.get("stream_name") in streams_to_sync
+        test_catalogs = [
+            c for c in found_catalogs if c.get("stream_name") in self.STREAMS_TO_SYNC
         ]
-
-        # Verify we have expected streams in catalog & sync
         self.perform_and_verify_table_and_field_selection(conn_id, test_catalogs)
-        self.run_and_verify_sync_mode(conn_id)
-        synced_records = runner.get_records_from_target_output()
 
-        # Helper function to extract upsert messages and validate their structure.
-        def upserts(stream_name):
+        # --- create test data -------------------------------------------
+        # Use fixed pre-indexed parent page; create all blocks under it.
+        # No wait needed because parent is already indexed and blocks are fetched by ID.
+        page_id = self.PARENT_PAGE_ID
+
+        text_1_id = self._append_block(page_id, "text_1")
+        self.addCleanup(self._archive_block, text_1_id)
+
+        text_1_child1_id = self._append_block(text_1_id, "text_1_child1")
+        text_1_child2_id = self._append_block(text_1_id, "text_1_child2")
+
+        # Create third-level grandchildren.
+        text_1_child2_grandchild1_id = self._append_block(
+            text_1_child2_id,
+            "text1_child2_grandchild1",
+        )
+        text_1_child2_grandchild2_id = self._append_block(
+            text_1_child2_id,
+            "text1_child2_grandchild2",
+        )
+
+        # --- tap-tester sync (no wait; parent is pre-indexed, blocks fetched by ID) --------------------------------------------
+        # --- extract upsert payloads ------------------------------------
+        def upserts(synced_records, stream_name):
             messages = synced_records.get(stream_name, {}).get("messages", [])
             upsert_messages = [
-                msg for msg in messages if isinstance(msg, dict) and msg.get("action") == "upsert"
+                msg for msg in messages
+                if isinstance(msg, dict) and msg.get("action") == "upsert"
             ]
             invalid_upserts = [
                 msg for msg in upsert_messages if not isinstance(msg.get("data"), dict)
@@ -61,84 +145,102 @@ class NotionNestedHierarchyTest(NotionBaseTest):
             )
             return [msg["data"] for msg in upsert_messages]
 
-        pages = upserts("pages")
-        blocks = upserts("blocks")
-        block_children = upserts("block_children")
+        self.run_and_verify_sync_mode(conn_id)
+        synced_records = runner.get_records_from_target_output()
 
-        self.assertGreater(len(pages), 0, "Expected at least one page record.")
-        self.assertGreater(len(blocks), 0, "Expected at least one block record.")
-        self.assertGreater(
-            len(block_children),
-            0,
-            "Expected at least one block_children record.",
-        )
+        pages = upserts(synced_records, "pages")
+        blocks = upserts(synced_records, "blocks")
+        block_children = upserts(synced_records, "block_children")
 
-        # Validating pages have primary keys and linked blocks
-        pages_missing_primary_key = [record for record in pages if not record.get("id")]
-        self.assertEqual(
-            pages_missing_primary_key,
-            [],
-            "Expected every page record to include mandatory primary key field "
-            "'id' ",
-        )
+        # --- assert primary keys present -------
+        pages_missing_pk = [r for r in pages if not r.get("id")]
+        self.assertEqual(pages_missing_pk, [], "Every page record must have 'id'.")
 
-        page_ids = {record["id"] for record in pages}
-        page_blocks = [
-            record for record in blocks if record.get("page_id") in page_ids
-        ]
+        blocks_missing_pk = [r for r in blocks if not r.get("id")]
+        self.assertEqual(blocks_missing_pk, [], "Every block record must have 'id'.")
 
-        self.assertGreater(
-            len(page_blocks),0,"Expected at least one block linked to a replicated page.",
-        )
-
-        # Validating blocks have primary keys and linked block_children
-        blocks_missing_primary_key = [
-            record for record in page_blocks if not record.get("id")
+        block_children_missing_pk = [
+            r for r in block_children if not r.get("id") or not r.get("block_id")
         ]
         self.assertEqual(
-            blocks_missing_primary_key,
+            block_children_missing_pk,
             [],
-            "Expected every parent block record to include mandatory primary key "
-            "field 'id' ",
+            "Every block_children record must have 'id' and 'block_id'.",
         )
 
-        # Validating block_children have primary keys and linked parent blocks
-        block_children_missing_primary_keys = [
-            record
-            for record in block_children
-            if not record.get("id") or not record.get("block_id")
+        # --- assert parent-child linkage at each level -------
+        # Level 1: text_1 is a direct child of the page → lands in blocks stream.
+        l1_blocks = [
+            r for r in blocks
+            if self._normalize_id(r.get("id")) == self._normalize_id(text_1_id)
         ]
+        self.assertTrue(l1_blocks, f"Top-level block {text_1_id} not found in blocks stream.")
         self.assertEqual(
-            block_children_missing_primary_keys,
-            [],
-            "Expected every block_children record to include mandatory key fields "
-            "'id' and 'block_id' ",
+            self._normalize_id(l1_blocks[0].get("page_id")),
+            self._normalize_id(page_id),
+            f"Top-level block must have page_id={page_id}.",
         )
 
-        # Building a mapping of parent blocks to their child blocks
-        children_by_parent = {}
-        for record in block_children:
-            parent_id = record.get("block_id")
-            child_id = record.get("id")
-            children_by_parent.setdefault(parent_id, set()).add(child_id)
-
-        parent_block_ids = {record["id"] for record in page_blocks}
-        direct_child_ids = set()
-        for parent_id in parent_block_ids:
-            direct_child_ids.update(children_by_parent.get(parent_id, set()))
-
-        self.assertGreater(
-            len(direct_child_ids),
-            0,
-            "Expected at least one child block under replicated parent blocks.",
+        # Level 2: both child blocks are in block_children linked to text_1.
+        level_2_records = {
+            self._normalize_id(r.get("id")): r
+            for r in block_children
+            if self._normalize_id(r.get("id")) in {
+                self._normalize_id(text_1_child1_id),
+                self._normalize_id(text_1_child2_id),
+            }
+        }
+        self.assertEqual(
+            set(level_2_records.keys()),
+            {
+                self._normalize_id(text_1_child1_id),
+                self._normalize_id(text_1_child2_id),
+            },
+            "Expected both second-level child blocks to be replicated in block_children.",
+        )
+        self.assertEqual(
+            self._normalize_id(
+                level_2_records[self._normalize_id(text_1_child1_id)].get("block_id")
+            ),
+            self._normalize_id(text_1_id),
+            f"text_1_child1 must have block_id={text_1_id}.",
+        )
+        self.assertEqual(
+            self._normalize_id(
+                level_2_records[self._normalize_id(text_1_child2_id)].get("block_id")
+            ),
+            self._normalize_id(text_1_id),
+            f"text_1_child2 must have block_id={text_1_id}.",
         )
 
-        grandchild_ids = set()
-        for child_id in direct_child_ids:
-            grandchild_ids.update(children_by_parent.get(child_id, set()))
-
-        self.assertGreater(
-            len(grandchild_ids),
-            0,
-            "Expected at least one grandchild block under replicated child blocks.",
+        # Level 3: both grandchildren are in block_children linked to text_1_child2.
+        level_3_records = {
+            self._normalize_id(r.get("id")): r
+            for r in block_children
+            if self._normalize_id(r.get("id")) in {
+                self._normalize_id(text_1_child2_grandchild1_id),
+                self._normalize_id(text_1_child2_grandchild2_id),
+            }
+        }
+        self.assertEqual(
+            set(level_3_records.keys()),
+            {
+                self._normalize_id(text_1_child2_grandchild1_id),
+                self._normalize_id(text_1_child2_grandchild2_id),
+            },
+            "Expected both third-level grandchild blocks to be replicated in block_children.",
+        )
+        self.assertEqual(
+            self._normalize_id(
+                level_3_records[self._normalize_id(text_1_child2_grandchild1_id)].get("block_id")
+            ),
+            self._normalize_id(text_1_child2_id),
+            f"text1_child2_grandchild1 must have block_id={text_1_child2_id}.",
+        )
+        self.assertEqual(
+            self._normalize_id(
+                level_3_records[self._normalize_id(text_1_child2_grandchild2_id)].get("block_id")
+            ),
+            self._normalize_id(text_1_child2_id),
+            f"text1_child2_grandchild2 must have block_id={text_1_child2_id}.",
         )


### PR DESCRIPTION
## JIRA: https://qlik-dev.atlassian.net/browse/SAC-31379

### Changes:
1. Establishes a connection/bookmark before creating test data
2. Creates a branched block hierarchy under a fixed pre-indexed parent page:
   - `text_1` (direct child → `blocks` stream)
   - `text_1_child1`, `text_1_child2` (nested → `block_children` stream)
   - Two grandchildren under `text_1_child2` (deeply nested → `block_children` stream)
3. Runs a full sync and validates:
   - All three streams contain records with required primary keys
   - Level 1 block has correct `page_id` linkage
   - Level 2 blocks have correct `block_id` linkage to their parent
   - Level 3 grandchild blocks have correct `block_id` linkage to their parent
4. Archives the top-level test block on cleanup (cascades to all children)

**Design decisions:**
- Uses a hardcoded pre-indexed parent page ID instead of creating new pages, avoiding Notion search API eventual-consistency delays
- All block creation uses the `/blocks/{id}/children` endpoint which is consistent immediately
- No `sleep`/`wait` required — test is deterministic and fast


Note: This can be improved further by adding polling even with preindexed page logic to avoid natural inconsistency delays due to Notion API but this solution is deterministic and reliable as it is for now.